### PR TITLE
Use @guardian/actions-riff-raff to deploy via RR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,6 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: [test]
-    if: github.ref == 'refs/heads/main'
 
     # Required by aws-actions/configure-aws-credentials
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,28 +6,58 @@ env:
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.17'
+      - uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
 
-    - name: Run tests
-      run: go test .
-    - name: Vet
-      run: go vet .
-    - name: Build
-      run: |
-        GOOS=linux GOARCH=arm64 go build -o $BINARY_NAME-arm64 main.go
-        GOOS=linux GOARCH=amd64 go build -o $BINARY_NAME-amd64 main.go
+      - name: Run tests
+        run: go test .
+      - name: Vet
+        run: go vet .
+  upload:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: github.ref == 'refs/heads/main'
 
-    - uses: actions/upload-artifact@v2
-      with:
-        path: ${{ env.BINARY_NAME }}-*
+    # Required by aws-actions/configure-aws-credentials
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
+      - name: Build
+        run: |
+          GOOS=linux GOARCH=arm64 go build -o $BINARY_NAME-arm64 main.go
+          GOOS=linux GOARCH=amd64 go build -o $BINARY_NAME-amd64 main.go
+
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+      - uses: guardian/actions-riff-raff@main
+        with:
+          app: instance-tag-discovery
+          stack: deploy
+          deployments: |
+            instance-tag-discovery:
+              type: aws-s3
+              sources: ${{ env.BINARY_NAME }}-arm64,${{ env.BINARY_NAME }}-amd64
+              parameters:
+                bucket: amigo-data
+                cacheControl: private
+                publicReadAcl: false

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ A simple program to fetch instance tags and write them to disk.
 
 Tags are fetched from (in order of preference):
 
-* instance metadata (IMDS v2 - enable tags via [Launch Template
+- instance metadata (IMDS v2 - enable tags via [Launch Template
   metadata](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata-metadataoptions.html#cfn-ec2-launchtemplate-launchtemplatedata-metadataoptions-instancemetadatatags))
-* the EC2 instance (EC2 API)
+- the EC2 instance (EC2 API)
 
 They are written to:
 
-* `/etc/config/tags.properties` (key=value format)
-* `/etc/config/tags.json` (JSON format)
+- `/etc/config/tags.properties` (key=value format)
+- `/etc/config/tags.json` (JSON format)
 
 The `out-dir` flag can be used to change the target directory.
 
@@ -40,10 +40,6 @@ The AWS SDK for Go has docs here:
 - https://aws.github.io/aws-sdk-go-v2/docs/ (developer guide)
 - https://pkg.go.dev/github.com/aws/aws-sdk-go-v2 (API reference)
 
-# Deployment
+## Deployment
 
-This tool is baked into images in the cdk-base role in AMIgo. In order to update
-it you should grab the built artifacts from the GitHub actions build and upload
-them to `packages/deb/` in the AMIgo data bucket.
-
-It would be nice to make this work with RiffRaff at some stage.
+This tools deploys via Riffraff whenever a PR is merged into main.


### PR DESCRIPTION
Uses https://github.com/guardian/actions-riff-raff/ to deploy via Riffraff.

A continuous deployment for `main->PROD` has also been added in Riffraff.

![Screenshot 2022-04-25 at 11 37 01](https://user-images.githubusercontent.com/858402/165073097-fb110528-1668-490d-bbdc-6ce75f00d95f.png)
