### PR TITLE
ci: Update `guardian/actions-riff-raff` from v1 to v4.3.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
 
-    # Required by aws-actions/configure-aws-credentials
     permissions:
-      id-token: write
       contents: read
+
+      # These permissions are required by guardian/actions-riff-raff...
+      id-token: write # ...to exchange an OIDC JWT ID token for AWS credentials
+      pull-requests: write #...to comment on PRs
 
     steps:
       - uses: actions/checkout@v2
@@ -44,13 +46,15 @@ jobs:
           GOOS=linux GOARCH=arm64 go build -o $BINARY_NAME-arm64 main.go
           GOOS=linux GOARCH=amd64 go build -o $BINARY_NAME-amd64 main.go
 
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: guardian/actions-riff-raff@v4.3.1
         with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-      - uses: guardian/actions-riff-raff@v1
-        with:
-          app: instance-tag-discovery
+          projectName: deploy::instance-tag-discovery
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          contentDirectories: |
+            instance-tag-discovery:
+              - ${{ env.BINARY_NAME }}-arm64
+              - ${{ env.BINARY_NAME }}-amd64
           config: |
             stacks:
               - deploy
@@ -62,9 +66,6 @@ jobs:
             deployments:
               instance-tag-discovery:
                 type: aws-s3
-                sources:
-                  - ${{ env.BINARY_NAME }}-arm64
-                  - ${{ env.BINARY_NAME }}-amd64
                 parameters:
                   bucket: amigo-data
                   cacheControl: private


### PR DESCRIPTION
> [!NOTE]
> Requires https://github.com/guardian/riffraff-platform/pull/745.

## What does this change?
CI is failing at the "upload to Riff-Raff" step. Technically, https://github.com/guardian/riffraff-platform/pull/745 should fix this.

In this change, I've updated https://github.com/guardian/actions-riff-raff to the latest version.

## How has this change been tested?
CI passing should suffice. Indeed it does:

<img width="624" height="557" alt="image" src="https://github.com/user-attachments/assets/4fac24ec-e44c-4dac-9dfb-5489a97aaba4" />
