### PR TITLE
chore: Add Dependabot configuration

### DIFF
--- a/.github/.github/dependabot.yaml
+++ b/.github/.github/dependabot.yaml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: quarterly
+    commit-message:
+      prefix: "chore(deps): "
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: quarterly
+    commit-message:
+      prefix: "chore(deps): "
+    groups:
+      # The AWS SDK dependencies must be updated in unison.
+      # See https://github.com/aws/aws-sdk-go-v2/issues/2370#issuecomment-1878423518.
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2"
+          - "github.com/aws/aws-sdk-go-v2/*"


### PR DESCRIPTION
## What does this change?
Adds an initial Dependabot configuration, using https://github.com/guardian/cognito-auth-lambdas/blob/main/.github/dependabot.yaml as inspiration.