### PR TITLE
ci: Obtain go version from `go.mod`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.17"
+          go-version-file: go.mod
 
       - name: Run tests
         run: go test .
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.17"
+          go-version-file: go.mod
       - name: Build
         run: |
           GOOS=linux GOARCH=arm64 go build -o $BINARY_NAME-arm64 main.go


### PR DESCRIPTION
> [!NOTE]
> This change is a no-op.

## What does this change?
This change makes `go.mod` the canonical place that defines the version of go used. I'm not sure if it'll result in Dependabot updating the version - https://github.com/dependabot/dependabot-core/issues/9057 suggests not, however https://github.com/guardian/actions-static-site/pull/102/changes suggests maybe?