### PR TITLE
fix: Use default credential provider chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install Go:
 Then run some commands:
 
     go test
-    go run main.go --profile [profile] --out-dir . --instance-id [some-id]
+    AWS_PROFILE=<profile> go run main.go --out-dir . --instance-id [some-id]
 
 If unsure about editors, we recommend using VS Code.
 

--- a/main.go
+++ b/main.go
@@ -23,14 +23,12 @@ const fileMode = 0644
 func main() {
 	outDirParam := flag.String("out-dir", "/etc/config/", "output directory")
 	instanceIDParam := flag.String("instance-id", "", "AWS instance id")
-	profileParam := flag.String("profile", "deployTools", "AWS credentials profile (useful if running locally)")
 
 	flag.Parse()
 
 	cfg, err := config.LoadDefaultConfig(
 		context.TODO(),
 		config.WithRegion("eu-west-1"),
-		config.WithSharedConfigProfile(*profileParam),
 	)
 	check(err, "error loading config")
 


### PR DESCRIPTION
## Context
This repository produces an [artifact for AMIgo](https://github.com/guardian/instance-tag-discovery/blob/ca8ebc13d2ee9c20925f71ee663ce948d776ac69/.github/workflows/ci.yaml#L49-L72),  which is baked into any AMI using the [`cdk-base` role](https://github.com/guardian/amigo/blob/610cf92210e0c8819a11f6c6a8938674f5cfbbf3/roles/cdk-base/tasks/main.yml#L14-L20). When the artifact runs, it produces two files: `/etc/config/tags.properties` and `/etc/config/tags.json`. The latter is [used by `guardian/devx-logs`](https://github.com/guardian/devx-logs/blob/bb0b80e145b193e164c4c1b553e468a7b1153ec9/ec2/main.go#L25) to generate FluentBit configuration to ship application and cloud-init logs to Central ELK.

We recently merged https://github.com/guardian/instance-tag-discovery/pull/26 which included some breaking changes[^1] to how credentials were obtained. It appears that passing a profile removed the other discovery paths from the standard provider chain. That is, when run on an EC2 instance, the instance profile was _not_ used, resulting in the following:

```console
root@ip-10-248-51-218:/var/lib/cloud/scripts/per-instance# ./00-instance-tag-discovery
2026/05/19 08:16:38 [instance-tag-discovery] error loading config; failed to get shared config profile, deployTools
```

Then when `guardian/devx-logs` runs, it [fails](https://github.com/guardian/devx-logs/blob/bb0b80e145b193e164c4c1b553e468a7b1153ec9/ec2/main.go#L73) to create FluentBit configuration:

```console
root@ip-10-248-51-218:/etc/td-agent-bit# cat /var/log/cloud-init-output.log | grep "tags not found"
tags not found: unable to read tags from /etc/config/tags.json: open /etc/config/tags.json: no such file or directory
```

The result of all this is a failure to ship application logs to Central ELK; the application is not impacted, however.

This is not immediate as the following need to occur:
- A new AMI needs to be created by AMIgo's schedule
- An application deployment needs to happen to pick up the new AMI

These events happened a number of days after the original PR was merged 😱 .

## What does this change?
By default, use the AWS SDK's default credential provider chain. The advice on https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html is to then set the `AWS_PROFILE` environment variable to use a specific profile.

> By default, the SDK checks the AWS_PROFILE environment variable to determine which profile to use. If no AWS_PROFILE variable is set, the SDK uses the default profile.
>
> Sometimes, you may want to use a different profile with your application. For example, you want to use the test-account credentials with your myapp application. You can use this profile by using the following command:
>
> ```bash
> $ AWS_PROFILE=test-account myapp
> ```

## How has this change been tested?
Logs for https://github.com/guardian/cdk-playground are not appearing. The above errors are from an EC2 instance for that service.

To test:
- We uploaded the artifact of this repository to a place in S3 accessible by `guardian/cdk-playground`
- Downloaded and executed the file:

   ```console
   aws s3 cp s3://<BUCKET>/deploy/CODE/cdk-playground/instance-tag-discovery-linux-arm64 00-instance-tag-discovery-fixed
   chmod u+x 00-instance-tag-discovery-fixed
  ./00-instance-tag-discovery-fixed

   2026/05/19 08:28:24 [instance-tag-discovery] Written 15 tags to /etc/config/tags.properties and /etc/config/tags.json
   ```
- We checked the contents of the generated files:

   ```console
   cat /etc/config/tags.json
   ```

The same is true for AMIable and after baking an AMI with these changes, the logs are appearing in Central ELK again:

<img width="1270" height="617" alt="image" src="https://github.com/user-attachments/assets/87e0bf94-00bf-481b-bccd-a8584fdefb82" />


[^1]: The AWS SDK for Go does not follow semver - https://github.com/aws/aws-sdk-go-v2/issues/2549.