### PR TITLE
chore: Update go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/guardian/instance-tag-discovery
 
-go 1.24
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.22


### PR DESCRIPTION
## What does this change?
Released on 02/06/2026, this version includes some security patches. See https://go.dev/doc/devel/release. This is being made after noticing an AWS Inspector finding against `go/stdlib`. Inspector suggests updating to at least 1.25.10.

## How has this change been tested?
There are a few things to check here.
1. Does the binary use the `go/stdlib` at version 1.25.10?

   To test this, we can download the [build artifacts from RIff-Raff](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=deploy%3A%3Ainstance-tag-discovery&id=91) and check:

    ```console
    ❯ go version -m instance-tag-discovery-linux-amd64
    instance-tag-discovery-linux-amd64: go1.26.4
    
    ❯ go version -m instance-tag-discovery-linux-arm64
    instance-tag-discovery-linux-arm64: go1.26.4
    ```

2. Does the binary produce the runtime output `/etc/config/tags.properties` and `/etc/config/tags.json`? To test this I:
   - Copied the artifact from Riff-Raff's bucket to a place accessible by https://github.com/guardian/cdk-playground:

    ```console
    aws s3 cp \
      s3://<RIFF_RAFF_BUCKET>/deploy::instance-tag-discovery/91/instance-tag-discovery/instance-tag-discovery-linux-arm64 \
      s3://<DIST_BUCKET>/deploy/CODE/cdk-playground/instance-tag-discovery-linux-arm64 \
      --profile deployTools
    ```

   - Connected to an EC2 instance of https://github.com/guardian/cdk-playground:
   
    ```console
    ssm ssh --profile deployTools -t cdk-playground,deploy,CODE -x
    ```

   - Downloaded the new binary:

    ```console
    aws s3 cp s3://<DIST_BUCKET>/deploy/CODE/cdk-playground/instance-tag-discovery-linux-arm64 .
    sudo chmod u+x instance-tag-discovery-linux-arm64
    ```

   - Deleted the existing runtime output:

    ```console
    sudo rm /etc/config/tags.properties
    sudo rm /etc/config/tags.json
    ```

   - Ran the new binary and saw the new runtime output:

    ```console
    sudo ./instance-tag-discovery-linux-arm64
    
    2026/06/04 19:17:44 [instance-tag-discovery] Written 18 tags to /etc/config/tags.properties and /etc/config/tags.json
    ```

3. Is the Inspector finding resolved?

    This one is quite involved and can only be understood once we've merged, baked a new AMI and brought that AMI into service. Once complete we can use the following [query in Service Catalogue](https://metrics.gutools.co.uk/goto/efo713r0er4zkb?orgId=1) to confirm:

    ```sql
    WITH data AS (
      SELECT  aws_account_id
              , finding_arn
              , first_observed_at
              , res ->> 'Type' AS resource_type
              , res ->> 'Id' AS resource_id
              , res -> 'Tags' ->> 'Stack' AS stack
              , res -> 'Tags' ->> 'Stage' AS stage
              , res -> 'Tags' ->> 'App' AS app
              , res -> 'Tags' ->> 'gu:repo' AS repo
              , res ->> 'Tags' AS tags
              , vulnerable_packages ->> 'FilePath' AS file_path
      FROM    aws_inspector2_findings 
              , JSONB_ARRAY_ELEMENTS(package_vulnerability_details -> 'VulnerablePackages') AS vulnerable_packages
              , JSONB_ARRAY_ELEMENTS(resources) AS res
    )
    
    SELECT  DISTINCT
            stack
            , stage
            , app
            , repo
    FROM    data 
    WHERE   file_path LIKE '%00-instance-tag-discovery'
    ````